### PR TITLE
Remove binder link for 2020 solutions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,5 @@ Binder repository for the chemometrics courses: [TKJ4175](https://www.ntnu.edu/s
 ### Most recent version exercises (master)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/andersle/chemometrics/master?filepath=%2Fexercises)
 
-### Most recent solutions (solutions_2020)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/andersle/chemometrics/solutions_2020?filepath=solutions%2F)
-
 ### Most recent version full repository (master)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/andersle/chemometrics/master)


### PR DESCRIPTION
This PR will remove the binder link for the 2020 solutions as these have now been removed.