### PR TITLE
Updated requirements for rdkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ seaborn
 pandas_profiling
 kneed
 bokeh
-rdkit-pypi
+rdkit


### PR DESCRIPTION
As per https://pypi.org/project/rdkit-pypi/:

> You can install RDKit using pip
>
> ``` pip install rdkit```
>
> **NOTE:** Older versions of RDKit might be available at the [rdkit-pypi](https://pypi.org/project/rdkit-pypi/) PyPi repository (pip install rdkit-pypi). rdkit-pypi is the old name of RDKit at PyPi. Future RDKit versions will be available at the rdkit PyPi repository. Please update your depenencies.